### PR TITLE
parse the connection URI and use the path when constructing requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,11 @@ sbt assembly
 The SlamData Engine API server must be running and accessible via the network. See
 [slamdata/slamengine](/slamdata/slamengine).
 
-You open a connection using the host name and port of the SlamEngine server,
-with a URL like `http://localhost:8080/`.
+You open a connection using a URL made up of the scheme `slamengine`, the 
+host name and port of the SlamData server, and the path within the SlamData 
+filesystem where your source files are found.
+
+For example `slamengine://localhost:8080/test/`.
 
 
 ### From Java
@@ -42,7 +45,7 @@ import java.sql.*;
 
 Driver driver = new slamdata.jdbc.SlamDataDriver();
       
-Connection cxn = driver.connect("http://localhost:8080/", null);
+Connection cxn = driver.connect("slamengine://localhost:8080/test/", null);
 try {
   Statement stmt = cxn.createStatement();
 
@@ -66,7 +69,7 @@ Note: error handling and resource cleanup elided above.
 
 Configure your tool to use `slamengine-jdbc_2.11-0.1-SNAPSHOT.jar`.
 
-Open a connection with a URL like `http://localhost:8080/`.
+Open a connection with a URL like `http://localhost:8080/test/`.
 
 Run queries...
 
@@ -75,4 +78,4 @@ Run queries...
 
 Released under ??? LICENSE. See [LICENSE](/slamdata/slamengine-jdbc/blob/master/LICENSE).
 
-Copyright 2014 SlamData Inc.
+Copyright 2014-2015 SlamData Inc.

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "slamengine-jdbc"
 
 version := "0.1-SNAPSHOT"
 
-scalaVersion := "2.11.2"
+scalaVersion := "2.11.7"
 
 initialize := {
   assert(
@@ -20,7 +20,5 @@ libraryDependencies ++= Seq(
 )
 
 licenses += ("GNU Affero GPL V3", url("http://www.gnu.org/licenses/agpl-3.0.html"))
-
-//com.github.retronym.SbtOneJar.oneJarSettings
 
 assemblySettings

--- a/src/main/scala/slamdata/jdbc/client.scala
+++ b/src/main/scala/slamdata/jdbc/client.scala
@@ -5,14 +5,16 @@ import argonaut._, Argonaut._
 import dispatch._, Defaults._
 
 class Client(val url: String) {
-  private val svc: Req = dispatch.url(url)
+  private def svc(entity: String): Req = {
+    val parsedUrl = new java.net.URI(url)
+    val port = if (parsedUrl.getPort < 0) 20223 else parsedUrl.getPort
+    dispatch.url("http://" + parsedUrl.getHost + ":" + port.toString + "/" + entity + "/fs/" + parsedUrl.getPath)
+  }
   
   def query(sql: String, vars: Map[String, String] = Map.empty, maxRows: Option[Int] = None): String \/ List[Json] = {
-    val outPath = "tmp/out"  // HACK
-
     def post: String \/ Json = {
-      val req = (svc / "query" / "fs" / "").POST.setHeader("Destination", outPath) <<? vars << sql
-  
+      val req = svc("query").POST.setHeader("Destination", "tmp0") <<? vars << sql
+      
       val exec = Http(req OK as.String)
       for {
         rez  <- \/.fromTryCatchNonFatal(exec()).leftMap(_.toString)  // FIXME
@@ -21,7 +23,7 @@ class Client(val url: String) {
    }
  
    def get(path: String): String \/ List[Json] = {
-     val req = svc / "data" / "fs" / "tmp" / "out"  // HACK
+     val req = svc("data") / path
      val limited = maxRows.map { max => req <<? Map("limit" -> max.toString) }.getOrElse(req)
 
      val exec = Http(limited OK as.String)
@@ -35,7 +37,8 @@ class Client(val url: String) {
      resp1 <- post
      path  <- (resp1.hcursor --\ "out").as[String].result.leftMap(_.toString)
   
-     resp2 <- get(path)
+     last = path.substring(path.lastIndexOf('/') + 1)
+     resp2 <- get(last)
     } yield resp2
   }
 }

--- a/src/test/scala/slamdata/jdbc/jdbc.scala
+++ b/src/test/scala/slamdata/jdbc/jdbc.scala
@@ -8,7 +8,7 @@ class DriverSpecs extends Specification {
     "connect to local server" in {
       val driver = new SlamDataDriver()
       
-      val cxn = driver.connect("http://localhost:8080/", null)
+      val cxn = driver.connect("slamengine://104.236.166.167:8080/demo/", null)
             
       cxn.close()
       
@@ -18,7 +18,7 @@ class DriverSpecs extends Specification {
     "run simple query" in {
       val driver = new SlamDataDriver()
       
-      val cxn = driver.connect("http://localhost:8080/", null)
+      val cxn = driver.connect("slamengine://104.236.166.167:8080/demo/", null)
       try {
 
         val stmt = cxn.createStatement
@@ -27,10 +27,6 @@ class DriverSpecs extends Specification {
       
         val hasNext = rs.next
       
-        // val count = rs.getInt("0")
-        //
-        // count must_== 29533
-        
         val rez = rs.getString("0")
         rez must_== "29353"
       }
@@ -38,7 +34,6 @@ class DriverSpecs extends Specification {
         cxn.close()
       }
     }
-
   }
   
   step {


### PR DESCRIPTION
Fixes #3, and allows the driver to work with current builds of SlamData (ca 2.1).

Also updated the README and bumped the scala version to 2.11.7.
